### PR TITLE
fix: prompt error on missing AWS region in user's config

### DIFF
--- a/src/providers/aws/runner.ts
+++ b/src/providers/aws/runner.ts
@@ -9,11 +9,16 @@ export class AwsInstanceRunner extends AbstractInstanceRunner {
     constructor(sm: StateManager) {
         super(sm)
 
-        if(!sm.get().provider?.aws) {
+        const state = sm.get()
+        if(!state.provider?.aws) {
             throw new Error(`Invalidate state: provider must be AWS, got state ${sm.get()}`)
         }
 
-        this.awsClient = new AwsClient(sm.name())
+        if(!state.provider?.aws?.provisionArgs || !sm.get().provider?.aws?.provisionArgs?.create) {
+            throw new Error(`Invalidate state: missing AWS provison args, got state ${sm.get()}`)
+        }
+
+        this.awsClient = new AwsClient(sm.name(), state.provider.aws?.provisionArgs?.create.region)
     }
 
     private getInstanceId(){

--- a/src/tools/aws.ts
+++ b/src/tools/aws.ts
@@ -1,28 +1,82 @@
 import { EC2Client, DescribeInstancesCommand, Instance, StartInstancesCommand, StopInstancesCommand, RebootInstancesCommand } from '@aws-sdk/client-ec2';
 import { STSClient, GetCallerIdentityCommand } from '@aws-sdk/client-sts';
 import { getLogger, Logger } from '../log/utils';
+import { loadConfig } from "@smithy/node-config-provider";
+import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@smithy/config-resolver";
+import { AccountClient, ListRegionsCommand } from "@aws-sdk/client-account";
+
+/**
+ * Region to use when no client region is configured
+ */
+export const DEFAULT_REGION = "us-east-1"
 
 export class AwsClient {
+
+
+    private static readonly staticLogger = getLogger(AwsClient.name)
+    
+    /**
+     * Return currently set region (as identified by AWS SDK).
+     * @returns currently configured region - undefined if not region currently set
+     */
+    static async getCurrentRegion(): Promise<string | undefined> {
+        // AWS SDK V3 does not provide an easy way to get current region
+        // Use this method taken from https://github.com/aws/aws-sdk-js-v3/discussions/4488
+        try {
+            return await loadConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS)()
+        } catch (e){
+            AwsClient.staticLogger.debug("Couldn't fin AWS region: ", e)
+            return undefined
+        }
+    }
+
+    static async listRegions(): Promise<string[]>{
+        // listRegions() may be called with no configured region
+        // Use a default region in such scenario
+        const region = await AwsClient.getCurrentRegion() ?? DEFAULT_REGION
+        const accountClient = new AccountClient({ region: region })
+        return AwsClient.listRegionWithPage(accountClient)
+    }
+
+    private static async listRegionWithPage(accountClient: AccountClient, nextToken?: string): Promise<string[]>{
+
+        const command = new ListRegionsCommand({ NextToken: nextToken});
+        const result = await accountClient.send(command)
+
+        const regions = result.Regions?.filter(r => r.RegionName).map(r => r.RegionName!) ?? [];
+        
+        if(result.NextToken){
+            return regions.concat(await this.listRegionWithPage(accountClient, result.NextToken))
+        } else {
+            return regions
+        }
+    }
 
     private readonly ec2Client: EC2Client
     private readonly stsClient: STSClient
     private readonly logger: Logger
+    private readonly region: string
 
-    constructor(name: string){
+    constructor(name: string, region: string){
         this.logger = getLogger(name)
-        this.ec2Client = new EC2Client({});
-        this.stsClient = new STSClient({});
+
+        // Region must be explicitely set as most operation require a region which may not be set by default
+        // Client code should prompt specify region in such case
+        this.region = region
+        this.ec2Client = new EC2Client({ region: this.region });
+        this.stsClient = new STSClient({ region: this.region });
     }
+
     async checkAuth() {
         this.logger.debug("Checking AWS authentication")
         try {
             const callerIdentity = await this.stsClient.send(new GetCallerIdentityCommand({}));
             this.logger.debug(`Currently authenticated as ${callerIdentity.UserId} on account ${callerIdentity.Account}`)
         } catch (e) {
-            this.logger.error(`Couldn't check AWS authentication: ${JSON.stringify(e)}`)
-            this.logger.error(`Is your local AWS authentication configured ?`)
+            this.logger.error(`Couldn't check AWS authentication`, e)
+            this.logger.error(`Is your local AWS config properly set ?`)
             
-            throw new Error(`Couldn't check AWS authentication: ${JSON.stringify(e)}`)
+            throw new Error(`Couldn't check AWS authentication ` + e)
         }
     }
 


### PR DESCRIPTION
sometime user sets their credentials without specifying a default region, in which case calling AWS client functions would result in an error. Now we make sure to either prompt user for region or use the one saved in state.