### PR TITLE
fix: Azure start should use start() and not restart() function

### DIFF
--- a/src/providers/azure/runner.ts
+++ b/src/providers/azure/runner.ts
@@ -42,7 +42,7 @@ export class AzureInstanceRunner extends AbstractInstanceRunner {
         const vmName = this.getVmName()
         const resourceGroupName = this.getResourceGroupName()
 
-        await this.client.restartInstance(resourceGroupName, vmName)
+        await this.client.startInstance(resourceGroupName, vmName)
     }
 
     async stop() {


### PR DESCRIPTION
otherwise Azure API fails as restarting a stopped instance is not allowed...