### PR TITLE
Sunshine password special characters handling

### DIFF
--- a/ansible/inventories/dev-vagrant.yml
+++ b/ansible/inventories/dev-vagrant.yml
@@ -17,6 +17,13 @@ all:
       sunshine_keyboard_variant: azerty
       sunshine_keyboard_model: pc104
       sunshine_keyboard_options: terminate:ctrl_alt_bksp
+
+      sunshine_web_username: sunshine
+      
+      # Password with special characters
+      # echo -n '@!/:,?!*#'"'"'€`_\µ$="foo' | base64 | base64 -d
+      # => @!/:,?!*#'€`_\µ$="foo
+      sunshine_web_password_base64: QCEvOiw/ISojJ+KCrGBfXMK1JD0iZm9v
     
       # sunshine_keyboard_layout: fr
       # sunshine_keyboard_variant: mac,azerty

--- a/ansible/roles/sunshine/templates/docker-compose.yml
+++ b/ansible/roles/sunshine/templates/docker-compose.yml
@@ -48,10 +48,9 @@ services:
 
       # Sunshine Web UI password
       # If unset or empty, can be set via Web UI directly
-      # Replace $ by $$ to avoid unwanted variable interpolation by Compose (See https://docs.docker.com/reference/compose-file/interpolation/)
-      SUNSHINE_WEB_PASSWORD: {{ sunshine_web_password_base64 | b64decode | replace('$', '$$') | quote }}
-      SUNSHINE_WEB_USERNAME: {{ sunshine_web_username | quote }}
-      SUNSHINE_SERVER_NAME: {{ sunshine_server_name | quote }}
+      SUNSHINE_WEB_PASSWORD_BASE64: "{{ sunshine_web_password_base64 }}"
+      SUNSHINE_WEB_USERNAME: "{{ sunshine_web_username }}"
+      SUNSHINE_SERVER_NAME: "{{ sunshine_server_name }}"
 
       # Optional additional Sunshine config
       # Use "\n" for multiple lines

--- a/containers/sunshine/overlay/cloudy/bin/start-sunshine.sh
+++ b/containers/sunshine/overlay/cloudy/bin/start-sunshine.sh
@@ -9,7 +9,8 @@ mkdir -p $CLOUDYPAD_DATA_DIR/sunshine
 envsubst < $CLOUDYPAD_CONF_DIR/sunshine/sunshine.conf.template > $CLOUDYPAD_CONF_DIR/sunshine/sunshine.conf
 
 # Set credentials if both Sunshine Web UI password and username are present
-if [[ -n "$SUNSHINE_WEB_PASSWORD" && -n "$SUNSHINE_WEB_USERNAME" ]]; then
+if [[ -n "$SUNSHINE_WEB_PASSWORD_BASE64" && -n "$SUNSHINE_WEB_USERNAME" ]]; then
+    SUNSHINE_WEB_PASSWORD=$(echo "$SUNSHINE_WEB_PASSWORD_BASE64" | base64 -d)
     sunshine $CLOUDYPAD_CONF_DIR/sunshine/sunshine.conf --creds $SUNSHINE_WEB_USERNAME $SUNSHINE_WEB_PASSWORD
 fi
 


### PR DESCRIPTION
some password with special characters were not handled properly, such as password starting with '@' or '`' which are YAML reserved scalars. Also the "quote" Ansible filter didn't behave as expected as it's reserved for shell not YAML...

Now passing it all as base64 encoded string and
decoding as close as possible without passing
decoded string around.