### PR TITLE
fix: pick up new amis automatically

### DIFF
--- a/src/providers/aws/pulumi.ts
+++ b/src/providers/aws/pulumi.ts
@@ -254,13 +254,14 @@ async function awsPulumiProgram(): Promise<Record<string, any> | void> {
 
     const ubuntuAmi = aws.ec2.getAmiOutput({
         mostRecent: true,
+        nameRegex: "^ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-[0-9]{8}$",
         filters: [
             {
                 name: "name",
                 // Use a specific version as much as possible to avoid reproducibility issues
                 // Can't use AMI ID as it's region dependent 
                 // and specifying AMI for all regions may not yield expected results and would be hard to maintain
-                values: ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20250115"],
+                values: ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"],
             },
             {
                 name: "virtualization-type",


### PR DESCRIPTION
Currently, the AMI lookup for AWS is failing in eu-central-1 and eu-west-1, at least for me. It seems that is because the AMI name that is hardcoded is not available anymore, as it has been replaced by releases with newer dates. The error logs look something like this (unfortunately, no actual error is being printed):

```
pulumi:pulumi:Stack CloudyPad-AWS-cloud-gaming running error: Unhandled exception: Error: invocation of aws:ec2/getAmi:getAmi returned an error: invoking aws:ec2/getAmi:getAmi: 1 error occurred:
```

Instead of hardcoding the date I have now updated the code to lookup the newest AMI release for the given Ubuntu release, so that cloudypad remains compatible without always having to update that number manually.

I tested this by building a new Docker image with this change and then running the commands in my environment. With these changes, the stack can now finish provisioning.