### PR TITLE
feat: manual pairing process to enter PIN manually

### DIFF
--- a/src/core/moonlight/pairer/abstract.ts
+++ b/src/core/moonlight/pairer/abstract.ts
@@ -1,4 +1,5 @@
 import { getLogger } from "../../../log/utils"
+import { input, select } from '@inquirer/prompts';
 
 /**
  * Moonlight pairing interface. Automates pairing process between Moonlight and streaming server.
@@ -20,26 +21,35 @@ export interface MoonlightPairer {
 
 export interface AbstractMoonlightPairerArgs {
     instanceName: string
+    host: string
 }
 
 export abstract class AbstractMoonlightPairer implements MoonlightPairer {
     
     protected readonly logger = getLogger(AbstractMoonlightPairer.name)
     protected readonly instanceName: string
+    protected readonly host: string
 
     constructor(args: AbstractMoonlightPairerArgs){
         this.instanceName = args.instanceName
+        this.host = args.host
     }
     
     abstract pairSendPin(pin: string, retries?: number, retryDelay?: number): Promise<boolean>
 
+    /**
+     * Pair with the streaming server interactively: prompt for PIN or generate PIN and send pairing request
+     * in the background. Both pairing methods are supported:
+     * - Automated: a PIN is generated and sent to the streaming server, user can run a `moonlight pair` command with pre-defined PIN
+     * - Manual: let user initiate pairing process via Moonlight and enter PIN in prompt
+     */
     async pairInteractive(){
         
         this.logger.debug(`Pairing instance ${this.instanceName} with Sunshine`)
 
         try {
 
-            await this.doPair()
+            await this.doPairInteractive()
 
             console.info(`Instance ${this.instanceName} paired successfully 🤝 👍`)
             console.info(`You can now run Moonlight to connect and play with your instance 🎮`)
@@ -48,7 +58,75 @@ export abstract class AbstractMoonlightPairer implements MoonlightPairer {
         }
     }
 
-    protected abstract doPair(): Promise<void>
+    private async doPairInteractive(){
+        
+        try {
+
+            const pairManual = "manual"
+            const pairAuto = "auto"
+
+            const pairMethod = await select({
+                message: 'Pair Moonlight automatically or run Moonlight yourself to pair manually ?',
+                default: pairAuto,
+                choices: [{
+                    name: "manual: run Moonlight yourself to pair your instance.",
+                    value: pairManual
+                }, {
+                    name: "automatic: run a single command to pair your instance.",
+                    value: pairAuto
+                }],
+                loop: false,
+            })
+
+            if(pairMethod === pairManual) {
+                await this.initiatePairManual()
+            } else if (pairMethod === pairAuto){
+                await this.initiatePairAuto()
+            } else {
+                throw new Error(`Unrecognized pair method '${pairMethod}'. This is probably an internal bug.`)
+            }
+
+        } catch (error) {
+            throw new Error(`Instance pairing failed.`, { cause: error })
+        }
+    }
+
+    private async initiatePairManual(){
+        console.info(`Run Moonlight and add instance manually (top right '+' button):`)
+        console.info()
+        console.info(`  ${this.host}`)
+        console.info()
+        console.info("Then click on the new machine (with a lock icon). It will show a PIN we'll use to pair your instance.")
+        console.info()
+
+        const pin = await input({
+            message: 'Enter PIN shown by Moonlight to finalize pairing:',
+        })
+
+        await this.doPair(pin)
+
+    }
+
+    private async initiatePairAuto(){
+        const pin = makePin()
+
+        console.info(`Run this command to pair your instance:`)
+        console.info()
+        console.info(`  moonlight pair ${this.host} --pin ${pin}`)
+        console.info()
+        console.info(`For Mac / Apple devices, you may need to use this pseudo-IPv6 address:`)
+        console.info()
+        console.info(`  moonlight pair ::ffff:${this.host} --pin ${pin}`)
+        console.info()
+        
+        await this.doPair(pin)
+    }
+
+    /**
+     * Pair with the streaming server by sending the provided PIN
+     */
+    protected abstract doPair(pin: string): Promise<void>
+
 }
 
 

--- a/src/core/moonlight/pairer/sunshine.ts
+++ b/src/core/moonlight/pairer/sunshine.ts
@@ -21,7 +21,8 @@ export class SunshineMoonlightPairer extends AbstractMoonlightPairer implements 
 
     constructor(args: SunshineMoonlightPairerArgs) {
         super({
-            instanceName: args.instanceName
+            instanceName: args.instanceName,
+            host: args.host
         })
         this.args = args
     }
@@ -30,20 +31,8 @@ export class SunshineMoonlightPairer extends AbstractMoonlightPairer implements 
         return new SSHClient(this.args.ssh);
     }
 
-    protected async doPair() {
+    protected async doPair(pin: string) {
 
-        const pin = makePin()
-
-        console.info(`Run this command in another terminal to pair your instance:`)
-        console.info()
-        console.info(`  moonlight pair ${this.args.host} --pin ${pin}`)
-        console.info()
-        console.info(`For Mac / Apple devices, you may need to use this pseudo-IPv6 address:`)
-        console.info()
-        console.info(`  moonlight pair [::ffff:${this.args.host}] --pin ${pin}`)
-        console.info()
-        console.info(`Sending PIN to Sunshine API...`)
-        
         const ssh = this.buildSshClient()
     
         // try to pair for 2 min by punshing through Sunshine API with our pin


### PR DESCRIPTION
as some user run Moonlight on other devices (eg. Steam Deck or smart TV) it's not possible for them to run a moonlight command which would only pair them desktop. Manual method allow more flexibility.