### PR TITLE
fix(sunshine): launcher use start command instead of plain binary

### DIFF
--- a/containers/sunshine/overlay/cloudy/conf/xfce4-default/panel/launcher-11/heroic.desktop
+++ b/containers/sunshine/overlay/cloudy/conf/xfce4-default/panel/launcher-11/heroic.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Heroic
 Comment=Application for managing and playing games on Steam
-Exec=heroic
+Exec=heroic-start.sh
 Icon=heroic
 Terminal=false
 Type=Application

--- a/containers/sunshine/overlay/cloudy/conf/xfce4-default/panel/launcher-12/lutris.desktop
+++ b/containers/sunshine/overlay/cloudy/conf/xfce4-default/panel/launcher-12/lutris.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Leroic
 Comment=Application for managing and playing games on Steam
-Exec=/usr/games/lutris
+Exec=lutris-start.sh
 Icon=lutris
 Terminal=false
 Type=Application

--- a/containers/sunshine/overlay/cloudy/conf/xfce4-default/panel/launcher-9/steam.desktop
+++ b/containers/sunshine/overlay/cloudy/conf/xfce4-default/panel/launcher-9/steam.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Steam
 Comment=Application for managing and playing games on Steam
-Exec=/usr/bin/steam steam://open/games
+Exec=steam-start.sh
 Icon=steam
 Terminal=false
 Type=Application


### PR DESCRIPTION
the start.sh commands ensure initial setup is done properly. Bypassing these may cause launcher to start with incorrect config