### PR TITLE
Fix Docker command array expansion for SSH agent

### DIFF
--- a/cloudypad.sh
+++ b/cloudypad.sh
@@ -161,7 +161,7 @@ run_cloudypad_docker() {
 
     # Add SSH agent volume and env var if it's available locally
     if [ -n "$SSH_AUTH_SOCK" ]; then
-        cmd+=" -v $SSH_AUTH_SOCK:/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent"
+        cmd+=(-v "$SSH_AUTH_SOCK:/ssh-agent" -e SSH_AUTH_SOCK=/ssh-agent)
     fi
 
     # If first arg is "debug-container" run a bash as entrypoint


### PR DESCRIPTION
This pull request makes a minor improvement to the way Docker command arguments are constructed in the `run_cloudypad_docker()` function. The change switches from string concatenation to using an array for Docker command options, which is more robust and helps prevent issues with argument parsing.

* Refactored Docker command argument construction to use an array (`cmd+=(...)`) instead of string concatenation for SSH agent volume and environment variable handling in `cloudypad.sh`.