### PR TITLE
fix: Wolf does not include custom per-provider variables

### DIFF
--- a/ansible/sunshine.yml
+++ b/ansible/sunshine.yml
@@ -13,7 +13,6 @@
 - name: Sunshine container
   hosts: all
   pre_tasks:
-    
     - name: Check if provider specific vars file exists
       set_fact:
         provider_vars_exists: "{{ lookup('file', 'providers/' + cloudypad_provider + '/vars.yml', errors='ignore') is not none }}"
@@ -37,9 +36,6 @@
       become: true
       docker_users:
       - "{{ ansible_user_id }}"
-      vars:
-        # Do not add Docker repository on Scaleway as it's already set and keyrings would conflict otherwise
-        docker_add_repo: "{{ cloudypad_provider != 'scaleway' }}"
     
     - role: roles/nvidia-driver
       tags: [ nvidia ]

--- a/ansible/wolf.yml
+++ b/ansible/wolf.yml
@@ -10,6 +10,15 @@
 
 - name: Install Docker, NVIDIA drivers and Wolf
   hosts: all
+  pre_tasks:
+    - name: Check if provider specific vars file exists
+      set_fact:
+        provider_vars_exists: "{{ lookup('file', 'providers/' + cloudypad_provider + '/vars.yml', errors='ignore') is not none }}"
+
+    - name: Load provider specific vars
+      include_vars: "providers/{{ cloudypad_provider }}/vars.yml"
+      when: provider_vars_exists
+
   roles:
     - role: roles/prepare-install
       become: true


### PR DESCRIPTION
- add missing pre_tasks in `ansible/wolf.yml`
- remove redundant `docker_add_repo` var in `ansible/sunshine.yml`

fixes #292 