### PR TITLE
fix: move PNPM_HOME to /usr/local/share/pnpm so non-root users can execute cloudypad

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt update && apt install -y \
 # Requires PNPM_HOME on PATH
 # Cache mounts are used later using these paths
 # pnpm requires global-bin-dir to exist and be on PATH
-ENV PNPM_HOME="/root/.local/share/pnpm"
+ENV PNPM_HOME="/usr/local/share/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 
 RUN npm install -g pnpm && \


### PR DESCRIPTION
## Problem

When building the image locally and running via `cloudypad.sh`, the `cloudypad` binary is unreachable by the container's executing user:

```
/bin/sh: 0: cannot open /root/.local/share/pnpm/cloudypad: Permission denied
```

The binary is installed by the root user during the image build into `$HOME/.local/share/pnpm` (the default `PNPM_HOME`). Linux sets `/root` to mode `700`, so any non-root user cannot traverse into it — even if the binary itself were world-executable.

`cloudypad.sh` builds a thin wrapper image on top of the base image that adds a user matching the host's UID/GID, so the container always runs as a non-root user. When Docker resolves the `cloudypad` ENTRYPOINT through `PATH` (which includes `PNPM_HOME`), it hits the `/root` traversal block immediately.

## Fix

Set `PNPM_HOME` to `/usr/local/share/pnpm`, which is created with mode `755` and is traversable by all users — the appropriate location for a system-wide install in an image where the executing user is determined at runtime.

## Why has this been latent?

Unclear. I don't know why I'm the first person to run into this issue. It's reproducible on macOS with a recent Docker Desktop.

## Test plan

- [x] `docker build -t cloudypad-dev . && CLOUDYPAD_IMAGE=cloudypad-dev ./cloudypad.sh create aws --help` completes without permission errors