### PR TITLE
fix: persist Pulumi plugin cache across container runs

### DIFF
--- a/cloudypad.sh
+++ b/cloudypad.sh
@@ -154,6 +154,10 @@ run_cloudypad_docker() {
         "PULUMI_BACKEND_URL" "PULUMI_CONFIG_PASSPHRASE"
     )
 
+    # Pin PULUMI_HOME inside ~/.cloudypad so the plugin cache (provider binaries) persists
+    # across container runs without requiring a separate ~/.pulumi mount.
+    cmd+=" -e PULUMI_HOME=$HOME/.cloudypad/pulumi-home"
+
     for env_var in "${env_vars[@]}"; do
         if [ -n "${!env_var}" ]; then
             cmd+=" -e $env_var=${!env_var}"


### PR DESCRIPTION
## Summary

- Sets `PULUMI_HOME` to `~/.cloudypad/pulumi-home` in `cloudypad.sh` so Pulumi's plugin cache (provider binaries) is stored inside the already-mounted `~/.cloudypad` directory
- Without this, plugins like `pulumi-resource-aws` are re-downloaded on every container invocation

## Details

`~/.pulumi/plugins` contains provider binaries that Pulumi downloads at runtime. This directory was not bind-mounted, so plugins were re-downloaded on every container run (adding ~30–60s to every command).

Rather than mounting a separate `~/.pulumi` directory (which would require users to have Pulumi installed locally), `PULUMI_HOME` is redirected to `~/.cloudypad/pulumi-home`, which is already bind-mounted. This keeps all CloudyPad runtime state in one place.

Note: `~/.cloudypad/pulumi-backend/.pulumi` is the Pulumi state backend (stack checkpoints) and is already persisted. This change addresses only the separate plugin cache.

## Test plan

- [x] Run any `cloudypad` command twice; confirm second run does not re-download provider plugins
- [x] Confirm `~/.cloudypad/pulumi-home/plugins/` is populated after first run

🤖 Generated with [Claude Code](https://claude.com/claude-code)