### PR TITLE
feat: log message before base image snapshot creation

### DIFF
--- a/src/core/manager.ts
+++ b/src/core/manager.ts
@@ -333,6 +333,10 @@ export class GenericInstanceManager<ST extends InstanceStateV1> implements Insta
         // After provision and configure, create base image snapshot if enabled
         const currentState = await this.getState()
         if (currentState.provision.input.baseImageSnapshot?.enable) {
+            console.info("")
+            console.info("Creating a base image snapshot of your instance. This will stop the instance temporarily and may take several minutes.")
+            console.info("The snapshot is used to speed up future starts by skipping the initial setup steps.")
+            console.info("")
             await this.doBaseImageSnapshotProvision(opts)
         }
     }


### PR DESCRIPTION
## Summary

- Prints an informational message before starting the base image snapshot Pulumi run, explaining that the instance will stop and the process will take several minutes

## Motivation

The snapshot process stops the instance and then runs a Pulumi update with no prior output, which is confusing — it looks like something is wrong. The message gives new users context for what is happening and why.

## Test plan

- [ ] Create an instance with `--base-image-snapshot` and confirm the message appears before the Pulumi snapshot run

🤖 Generated with [Claude Code](https://claude.com/claude-code)