### PR TITLE
feat(aws): add DeployedBy and CloudyPadInstance tags to all resources

### DIFF
--- a/src/providers/aws/pulumi/base-image-snapshot.ts
+++ b/src/providers/aws/pulumi/base-image-snapshot.ts
@@ -166,7 +166,7 @@ export class AwsBaseImagePulumiClient extends InstancePulumiClient<PulumiStackCo
 
         const stack = await this.getStack()
         await stack.setConfig("aws:region", { value: config.region})
-        await stack.setConfig("additionalTags", { value: JSON.stringify([`instance:${config.instanceName}`])})
+        await stack.setConfig("additionalTags", { value: JSON.stringify([`CloudyPadInstance:${config.instanceName}`, `DeployedBy:cloudypad`])})
         if(config.rootVolumeId) await stack.setConfig("rootVolumeId", { value: config.rootVolumeId})
 
         const allConfs = await stack.getAllConfig()

--- a/src/providers/aws/pulumi/base-image-snapshot.ts
+++ b/src/providers/aws/pulumi/base-image-snapshot.ts
@@ -28,7 +28,6 @@ class CloudyPadAwsBaseImage extends pulumi.ComponentResource {
         super("crafteo:cloudypad:aws:base-image", name, args, opts)
 
         const globalTags = pulumi.all([args.additionalTags]).apply(([tags]) => [
-            name,
             ...tags
         ])
 

--- a/src/providers/aws/pulumi/data-volume-snapshot.ts
+++ b/src/providers/aws/pulumi/data-volume-snapshot.ts
@@ -120,7 +120,7 @@ export class AwsDataDiskSnapshotPulumiClient extends InstancePulumiClient<Pulumi
 
         const stack = await this.getStack()
         await stack.setConfig("aws:region", { value: config.region})
-        await stack.setConfig("additionalTags", { value: JSON.stringify([`instance:${config.instanceName}`])})
+        await stack.setConfig("additionalTags", { value: JSON.stringify([`CloudyPadInstance:${config.instanceName}`, `DeployedBy:cloudypad`])})
         await stack.setConfig("volumeId", { value: config.baseVolumeId})
 
         const allConfs = await stack.getAllConfig()

--- a/src/providers/aws/pulumi/data-volume-snapshot.ts
+++ b/src/providers/aws/pulumi/data-volume-snapshot.ts
@@ -25,7 +25,6 @@ class CloudyPadAwsDataDiskSnapshot extends pulumi.ComponentResource {
         super("crafteo:cloudypad:aws:data-disk-snapshot", name, args, opts)
 
         const globalTags = pulumi.all([args.additionalTags]).apply(([tags]) => [
-            name,
             ...tags
         ])
 

--- a/src/providers/aws/pulumi/main.ts
+++ b/src/providers/aws/pulumi/main.ts
@@ -145,7 +145,8 @@ class CloudyPadEC2Instance extends pulumi.ComponentResource {
         } else if (args.publicKeyContent){
             this.keyPair = new aws.ec2.KeyPair(`${name}-keypair`, {
                 publicKey: args.publicKeyContent,
-                keyName: awsResourceNamePrefix
+                keyName: awsResourceNamePrefix,
+                tags: globalTags,
             }, {
                 ...commonPulumiOpts,
                 ignoreChanges: args.ignorePublicKeyChanges ? [ "publicKey" ] : []

--- a/src/providers/aws/pulumi/main.ts
+++ b/src/providers/aws/pulumi/main.ts
@@ -310,6 +310,11 @@ async function awsPulumiProgram(): Promise<Record<string, any> | void> {
 
     const instanceName = pulumi.getStack()
 
+    const cloudypadTags = {
+        DeployedBy: "cloudypad",
+        CloudyPadInstance: instanceName,
+    }
+
     // Use provided imageId if available, otherwise use default Ubuntu AMI
     const amiId = imageId ? pulumi.output(imageId) : aws.ec2.getAmiOutput({
         mostRecent: true,
@@ -350,6 +355,7 @@ async function awsPulumiProgram(): Promise<Record<string, any> | void> {
     }
 
     const instance = new CloudyPadEC2Instance(instanceName, {
+        tags: cloudypadTags,
         ami: amiId,
         type: instanceType,
         availabilityZone: zone,

--- a/src/providers/aws/pulumi/main.ts
+++ b/src/providers/aws/pulumi/main.ts
@@ -180,7 +180,7 @@ class CloudyPadEC2Instance extends pulumi.ComponentResource {
                     ...args.tags,
                     Name: awsResourceNamePrefix
                 },
-                volumeTags: args.tags,
+                volumeTags: { ...args.tags, Name: `${awsResourceNamePrefix}-os` },
                 vpcSecurityGroupIds: [this.securityGroup.id],
                 keyName: this.keyPairName,
                 rootBlockDevice: {
@@ -213,7 +213,7 @@ class CloudyPadEC2Instance extends pulumi.ComponentResource {
                     size: args.dataDisk.sizeGb,
                     type: "gp3",
                     availabilityZone: this.ec2Instance.availabilityZone,
-                    tags: globalTags,
+                    tags: { ...globalTags, Name: `${awsResourceNamePrefix}-data` },
                     snapshotId: args.dataDisk.snapshotId,
                 }, {
                     ...commonPulumiOpts,


### PR DESCRIPTION
## Summary

- Adds `DeployedBy=cloudypad` and `CloudyPadInstance=<name>` tags to all AWS resources in all three Pulumi stacks (main, base image snapshot, data disk snapshot)
- Renames the existing `instance=<name>` tag on snapshot resources to `CloudyPadInstance=<name>` for consistency

## Details

The main stack's `CloudyPadEC2Instance` component already accepted an `args.tags` map that was spread into every resource's tags — it just wasn't being populated. This change passes `cloudypadTags` into the component at creation time.

The snapshot stacks used an `additionalTags` string-array mechanism with `instance:<name>` format. These are updated to use `CloudyPadInstance:<name>` and add `DeployedBy:cloudypad`.

## Test plan

- [ ] Create an instance and confirm all EC2/EBS/SG/EIP/KeyPair resources have `DeployedBy=cloudypad` and `CloudyPadInstance=<name>` tags in the AWS console
- [ ] Create an instance with base image snapshot enabled and confirm the EBS snapshot and AMI have the same tags
- [ ] Create an instance with data disk snapshot enabled and confirm the snapshot has the same tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)