### PR TITLE
docs: clarify Moonlight pairing and manual instance discovery

### DIFF
--- a/docs/src/usage/moonlight-pairing.md
+++ b/docs/src/usage/moonlight-pairing.md
@@ -10,17 +10,36 @@ Moonlight is available [Windows, MacOS and Linux](https://github.com/moonlight-s
 
 ## Run Moonlight and connect to your instance
 
-Pairing is done automatically when you run `cloudypad create`.
+### Step 1: Pair your instance
 
-If needed, can pair your instance using Cloudy Pad CLI:
+Pairing is done automatically when you run `cloudypad create`. If you need to pair again:
 
 ```sh
 cloudypad pair my-instance
-
-# Run this command in another terminal to pair your instance:
-#
-#   moonlight pair 35.181.136.176 --pin 1234
 ```
+
+Choose **automatic** pairing when prompted. Cloudy Pad will generate a PIN and display a command like:
+
+```sh
+moonlight pair 35.181.136.176 --pin 1234
+```
+
+Run that command in a separate terminal **while `cloudypad pair` is still waiting**. Both sides need to complete the handshake together.
+
+> **Important:** do not use Moonlight's GUI to initiate pairing (clicking the padlock icon). That flow requires entering a PIN in Sunshine's web interface, which is not directly accessible. Always use `cloudypad pair` and the `moonlight pair --pin` command.
+
+### Step 2: Add your instance in Moonlight
+
+Cloud instances are not on your local network, so Moonlight will not discover them automatically. You must add the instance IP address manually:
+
+1. Open Moonlight
+2. Click the **+** button (Add PC)
+3. Enter your instance's IP address (shown by `cloudypad list`)
+4. Click **OK**
+
+### Step 3: Connect
+
+Once paired and added, click your instance in Moonlight to connect and start streaming.
 
 ## Mac and Apple specificities
 

--- a/docs/src/usage/moonlight-pairing.md
+++ b/docs/src/usage/moonlight-pairing.md
@@ -10,9 +10,9 @@ Moonlight is available [Windows, MacOS and Linux](https://github.com/moonlight-s
 
 ## Run Moonlight and connect to your instance
 
-### Step 1: Pair your instance
+Pairing is done automatically when you run `cloudypad create`. If you need to pair again, follow these steps.
 
-Pairing is done automatically when you run `cloudypad create`. If you need to pair again:
+### Step 1: Start pairing
 
 ```sh
 cloudypad pair my-instance
@@ -24,22 +24,19 @@ Choose **automatic** pairing when prompted. Cloudy Pad will generate a PIN and d
 moonlight pair 35.181.136.176 --pin 1234
 ```
 
-Run that command in a separate terminal **while `cloudypad pair` is still waiting**. Both sides need to complete the handshake together.
+### Step 2: Run the Moonlight pair command
 
-> **Important:** do not use Moonlight's GUI to initiate pairing (clicking the padlock icon). That flow requires entering a PIN in Sunshine's web interface, which is not directly accessible. Always use `cloudypad pair` and the `moonlight pair --pin` command.
+Run the `moonlight pair` command shown above in a separate terminal **while `cloudypad pair` is still waiting**. Both sides need to complete the handshake together.
 
-### Step 2: Add your instance in Moonlight
+`moonlight pair` handles both pairing and adding the instance — after it completes, your instance will appear in Moonlight ready to connect.
 
-Cloud instances are not on your local network, so Moonlight will not discover them automatically. You must add the instance IP address manually:
+> **Important:** do not use Moonlight's GUI to initiate pairing (clicking the padlock icon on an instance). That flow requires entering a PIN in Sunshine's web interface, which is not directly accessible. Always use `cloudypad pair` and the `moonlight pair --pin` command instead.
 
-1. Open Moonlight
-2. Click the **+** button (Add PC)
-3. Enter your instance's IP address (shown by `cloudypad list`)
-4. Click **OK**
+> **Note:** Cloud instances are not on your local network so Moonlight will not discover them automatically. If your instance does not appear after pairing, open Moonlight, click **+**, and enter the IP address shown by `cloudypad list`.
 
 ### Step 3: Connect
 
-Once paired and added, click your instance in Moonlight to connect and start streaming.
+Click your instance in Moonlight to connect and start streaming.
 
 ## Mac and Apple specificities
 


### PR DESCRIPTION
## Summary

- Explains that cloud instances are not discoverable by Moonlight and must be added manually by IP
- Clarifies that pairing must use `cloudypad pair` + `moonlight pair --pin`, not Moonlight's GUI padlock flow (which requires the Sunshine web UI, which is localhost-only)
- Documents the timing requirement: both sides of the handshake must run simultaneously
- Adds numbered steps to make the full connect flow explicit

## Motivation

New users trying to connect see Moonlight's GUI pairing prompt (which shows a PIN and asks for the Sunshine web UI), not realising this is the wrong flow. The existing docs mention the commands but don't explain why or warn against the GUI flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)