### PR TITLE
fix: show actual instance name in destroy hint on create failure

### DIFF
--- a/src/providers/aws/cli.ts
+++ b/src/providers/aws/cli.ts
@@ -348,7 +348,7 @@ export class AwsCliCommandGenerator extends CliCommandGenerator {
                     console.error("")
                     console.error("⚠️ Your instance was not created successfully. To cleanup resources and avoid leaving orphaned resources which may be charged, run:")
                     console.error("")
-                    console.error("    cloudypad destroy <instance-name>")
+                    console.error(`    cloudypad destroy ${cliArgs.name ?? "<instance-name>"}`)
 
                     handleErrorAnalytics(error)
                     await cleanupAndExit(1)

--- a/src/providers/dummy/cli.ts
+++ b/src/providers/dummy/cli.ts
@@ -156,7 +156,7 @@ export class DummyCliCommandGenerator extends CliCommandGenerator {
                     console.error("")
                     console.error("⚠️ Your instance was not created successfully. To cleanup resources and avoid leaving orphaned resources which may be charged, run:")
                     console.error("")
-                    console.error("    cloudypad destroy <instance-name>")
+                    console.error(`    cloudypad destroy ${cliArgs.name ?? "<instance-name>"}`)
 
                     await cleanupAndExit(1)
                 }

--- a/src/providers/ssh/cli.ts
+++ b/src/providers/ssh/cli.ts
@@ -235,7 +235,7 @@ export class SshCliCommandGenerator extends CliCommandGenerator {
                     console.error("")
                     console.error("⚠️ Your instance was not created successfully. To cleanup resources and avoid leaving orphaned resources which may be charged, run:")
                     console.error("")
-                    console.error("    cloudypad destroy <instance-name>")
+                    console.error(`    cloudypad destroy ${cliArgs.name ?? "<instance-name>"}`)
 
                     await cleanupAndExit(1)
                 }


### PR DESCRIPTION
When instance creation fails, the error message now shows the actual instance name in the `cloudypad destroy` command instead of the placeholder `<instance-name>`. Falls back to `<instance-name>` if the name was not yet entered (e.g. failure before the interactive prompt).