### PR TITLE
fix: GCP data disk snapshot never refreshed after first stop cycle

### DIFF
--- a/src/providers/gcp/provisioner.ts
+++ b/src/providers/gcp/provisioner.ts
@@ -78,6 +78,8 @@ export class GcpProvisioner extends AbstractInstanceProvisioner<GcpProvisionInpu
             region: this.args.provisionInput.region,
             zone: this.args.provisionInput.zone,
             baseVolumeId: this.args.provisionOutput.dataDiskId,
+            // unique version to force a fresh snapshot on each call, see data-volume-snapshot.ts
+            snapshotVersion: Math.floor(Date.now() / 1000).toString(),
         })
         const snapshotOutput = await snapshotClient.up()
 

--- a/src/providers/gcp/pulumi/data-volume-snapshot.ts
+++ b/src/providers/gcp/pulumi/data-volume-snapshot.ts
@@ -15,6 +15,11 @@ interface GcpDataDiskSnapshotArgs {
      */
     volumeId: pulumi.Input<string>
     additionalTags: pulumi.Input<string[]>
+
+    /**
+     * Unique version identifier forcing snapshot replacement when it changes.
+     */
+    snapshotVersion: pulumi.Input<string>
 }
 
 class CloudyPadGcpDataDiskSnapshot extends pulumi.ComponentResource {
@@ -42,8 +47,13 @@ class CloudyPadGcpDataDiskSnapshot extends pulumi.ComponentResource {
             parent: this
         }
 
+        // Snapshot version in name forces replacement on each stop cycle (GCP snapshot names are immutable)
+        const snapshotName = pulumi.output(args.snapshotVersion).apply((version) =>
+            `${name}-data-volume-snapshot-${version}`.toLowerCase()
+        )
+
         const snapshot = new gcp.compute.Snapshot(`${name}-data-volume-snapshot`, {
-            name: `${name}-data-volume-snapshot`.toLowerCase(),
+            name: snapshotName,
             sourceDisk: args.volumeId,
             labels: globalTags,
         }, {
@@ -68,6 +78,7 @@ async function gcpDataDiskSnapshotPulumiProgram(): Promise<Record<string, any> |
     const config = new pulumi.Config()
     const volumeId = config.get("volumeId")
     const additionalTags = config.getObject<string[]>("additionalTags") || []
+    const snapshotVersion = config.require("snapshotVersion")
 
     const stackName = pulumi.getStack()
 
@@ -79,6 +90,7 @@ async function gcpDataDiskSnapshotPulumiProgram(): Promise<Record<string, any> |
     const snapshot = new CloudyPadGcpDataDiskSnapshot(stackName, {
         volumeId: volumeId,
         additionalTags: additionalTags,
+        snapshotVersion: snapshotVersion,
     })
 
     return {
@@ -97,6 +109,12 @@ export interface PulumiStackConfigGcpDataDiskSnapshot {
      * no-op. Any existing snapshot is KEPT and no new snapshot is created.
      */
     baseVolumeId?: string
+
+    /**
+     * Unique version identifier for the snapshot. A new value forces creation
+     * of a fresh snapshot replacing the previous one.
+     */
+    snapshotVersion: string
 }
 
 export interface GcpDataDiskSnapshotPulumiOutput {
@@ -126,6 +144,7 @@ export class GcpDataDiskSnapshotPulumiClient extends InstancePulumiClient<Pulumi
         await stack.setConfig("gcp:zone", { value: config.zone})
         await stack.setConfig("additionalTags", { value: JSON.stringify([`instance:${config.instanceName}`])})
         if(config.baseVolumeId) await stack.setConfig("volumeId", { value: config.baseVolumeId})
+        await stack.setConfig("snapshotVersion", { value: config.snapshotVersion})
 
         const allConfs = await stack.getAllConfig()
         this.logger.debug(`GCP snapshot stack config after update: ${JSON.stringify(allConfs)}`)


### PR DESCRIPTION
GCP data disk snapshot was only created on the first instance stop and
never updated afterwards, causing any data written after the first
stop/start cycle to be lost on restart

The snapshot stack relied on replaceOnChanges: ["sourceDisk"] to take a
fresh snapshot on each stop, a pattern inherited from AWS where a volume
restored from snapshot gets a brand new random ID (vol-xxx), naturally
triggering replacement. On GCP however the disk is identified by its
name (<instance>-data) which stays identical across delete/restore
cycles: Pulumi saw no diff on subsequent stops and silently kept the
stale snapshot.

Since GCP provides no naturally-changing input, introduce a synthetic
one: provisioner now passes a unique snapshotVersion (timestamp) on
every data snapshot provision, included in the snapshot name. GCP
snapshot names are immutable so the name change forces Pulumi to
replace the snapshot on every stop cycle.

Fix #388 
