### PR TITLE
fix: use SSHClient instead of broken Dockerode SSH transport for Wolf pairing

### DIFF
--- a/src/core/moonlight/pairer/wolf.ts
+++ b/src/core/moonlight/pairer/wolf.ts
@@ -1,11 +1,9 @@
-import * as fs from 'fs'
 import { input, select } from '@inquirer/prompts';
-import Docker from 'dockerode';
 import axios from 'axios';
 import { URL } from 'url'
 import { buildAxiosError, CloudyPadAxiosError } from '../../../tools/axios';
 import { AbstractMoonlightPairer, makePin, MoonlightPairer } from "./abstract";
-import { SSHClientArgs } from '../../../tools/ssh';
+import { SSHClient, SSHClientArgs } from '../../../tools/ssh';
 
 export interface WolfMoonlightPairerArgs {
     instanceName: string
@@ -29,39 +27,19 @@ export class WolfMoonlightPairer extends AbstractMoonlightPairer implements Moon
         throw new Error("Not implemented")
     }
 
-    private buildDockerClient(): Docker {
-
-        const privateKeyContent = this.args.ssh.privateKeyPath ? fs.readFileSync(this.args.ssh.privateKeyPath, 'utf-8') : undefined
-
-        const docker = new Docker({
-            host: this.args.host,
-            protocol: 'ssh',
-            port: 22,
-            username: this.args.ssh.user,
-            sshOptions: {
-                privateKey: privateKeyContent,
-                password: this.args.ssh.password
-            }
-        });
-
-        return docker
+    private buildSshClient(): SSHClient {
+        return new SSHClient(this.args.ssh)
     }
- 
-    private async getLatestPinURL(docker: Docker, host: string): Promise<string | undefined> {
-        const containerName = 'wolf';
-        const pinUrlLogMatch = 'Insert pin at';
-    
-        try {
-            const container = docker.getContainer(containerName)
 
-            const logs = (await container.logs({
-                stdout: true,
-                stderr: true,
-                tail: 500,
-            }))
-            .toString('utf-8')
-            .trim()
-            .split('\n')
+    private async getLatestPinURL(sshClient: SSHClient, host: string): Promise<string | undefined> {
+        const pinUrlLogMatch = 'Insert pin at';
+
+        try {
+            const result = await sshClient.command(['sh', '-c', 'docker logs wolf --tail 500 2>&1'], {
+                ignoreNonZeroExitCode: true
+            })
+
+            const logs = result.stdout.trim().split('\n')
 
             this.logger.trace(`Checking logs for PIN: ${JSON.stringify(logs)}`)
 
@@ -153,24 +131,20 @@ export class WolfMoonlightPairer extends AbstractMoonlightPairer implements Moon
      * Check if the pairing was successful by looking for a success message in the logs.
      * Only logs appearing after the given date are considered.
      */
-    private async checkPairingSuccess(docker: Docker, notBefore: Date): Promise<boolean> {
-        const containerName = 'wolf';
+    private async checkPairingSuccess(sshClient: SSHClient, notBefore: Date): Promise<boolean> {
         const successLogMatch = 'Succesfully paired';
 
         try {
-            const container = docker.getContainer(containerName)
+            // Docker CLI --since accepts a Unix timestamp in seconds
+            const sinceUnixSeconds = Math.floor(notBefore.getTime() / 1000)
 
-            const logs = (await container.logs({
-                stdout: true,
-                stderr: true,
-                tail: 100,
-                // Only check logs appeared after given date
-                // Actually use seconds and note UNX timestamp as documented by Docker API
-                since: (notBefore.getTime() / 1000), 
-            }))
-            .toString('utf-8')
-            .trim()
-            .split('\n')
+            const result = await sshClient.command(['sh', '-c',
+                `docker logs wolf --tail 100 --since ${sinceUnixSeconds} 2>&1`
+            ], {
+                ignoreNonZeroExitCode: true
+            })
+
+            const logs = result.stdout.trim().split('\n')
 
             // Check for success or failure messages in recent logs
             for (let i = logs.length - 1; i >= 0; i--) {
@@ -201,7 +175,7 @@ export class WolfMoonlightPairer extends AbstractMoonlightPairer implements Moon
 
         this.logger.debug(`Pairing instance ${this.instanceName} with Wolf for host ${this.args.host}`)
 
-        const docker = this.buildDockerClient()
+        const sshClient = this.buildSshClient()
         const timeout = 60 * 5 * 1000; // 5 minutes
         const pollInterval = 2000; // 2s
         const startTime = new Date();
@@ -209,42 +183,48 @@ export class WolfMoonlightPairer extends AbstractMoonlightPairer implements Moon
         // voluntary console.info to show in user's console
         console.info("Sending PIN to Wolf...")
 
-        while (Date.now() - startTime.getTime() < timeout) {
-            try {
+        try {
+            await sshClient.connect()
 
-                this.logger.debug(`Fetching latest PIN URL in logs of Wolf container...`)
+            while (Date.now() - startTime.getTime() < timeout) {
+                try {
 
-                const publicPinUrl = await this.getLatestPinURL(docker, this.args.host)
-         
-                if (!publicPinUrl) {
-                    this.logger.debug(`No PIN URL found in logs, waiting for user to initiate pairing...`)
+                    this.logger.debug(`Fetching latest PIN URL in logs of Wolf container...`)
+
+                    const publicPinUrl = await this.getLatestPinURL(sshClient, this.args.host)
+
+                    if (!publicPinUrl) {
+                        this.logger.debug(`No PIN URL found in logs, waiting for user to initiate pairing...`)
+                        await new Promise(resolve => setTimeout(resolve, pollInterval))
+                        continue;
+                    }
+
+                    this.logger.debug(`Sending PIN to ${publicPinUrl}...`)
+
+                    await this.sendPinData(publicPinUrl, pin)
+
+                    this.logger.debug(`Checking in logs if pairing was successful...`)
+
+                    const pairingSuccess = await this.checkPairingSuccess(sshClient, startTime)
+
+                    if (pairingSuccess) {
+                        this.logger.info(`Successfully paired instance ${this.instanceName} with Wolf`)
+                        return;
+                    }
+
+                    this.logger.debug(`Pairing not yet successful, will retry in ${pollInterval}ms...`)
                     await new Promise(resolve => setTimeout(resolve, pollInterval))
-                    continue;
+
+                } catch (e) {
+                    this.logger.error(`Failed to pair instance ${this.instanceName} with Wolf.`, { cause: e })
+                    await new Promise(resolve => setTimeout(resolve, pollInterval))
                 }
-
-                this.logger.debug(`Sending PIN to ${publicPinUrl}...`)
-
-                await this.sendPinData(publicPinUrl, pin)
-
-                this.logger.debug(`Checking in logs if pairing was successful...`)
-
-                const pairingSuccess = await this.checkPairingSuccess(docker, startTime)
-
-                if (pairingSuccess) {
-                    this.logger.info(`Successfully paired instance ${this.instanceName} with Wolf`)
-                    return;
-                }
-
-                this.logger.debug(`Pairing not yet successful, will retry in ${pollInterval}ms...`)
-                await new Promise(resolve => setTimeout(resolve, pollInterval))
-
-            } catch (e) {
-                this.logger.error(`Failed to pair instance ${this.instanceName} with Wolf.`, { cause: e })
-                await new Promise(resolve => setTimeout(resolve, pollInterval))
             }
-        }
 
-        throw new Error(`Failed to pair instance ${this.instanceName} with Wolf after ${timeout}ms timeout`);
+            throw new Error(`Failed to pair instance ${this.instanceName} with Wolf after ${timeout}ms timeout`);
+        } finally {
+            sshClient.dispose()
+        }
     }
         
 }


### PR DESCRIPTION
## Summary

Fixes #379 — Wolf pairing throws `TypeError [ERR_INVALID_ARG_VALUE]: Invalid port in url` in a loop and never sends the PIN.

## Root cause

`WolfMoonlightPairer` fetches the `wolf` container's logs (to find the PIN URL and confirm pairing success) through a Dockerode client configured with `protocol: 'ssh'` and a plain `host`. Internally, `docker-modem`'s `Modem.dial()` builds the request URL with Node's legacy `url` module. Since `'ssh'` isn't in `docker-modem`'s hardcoded list of "slashed" protocols (`http`, `https`, `ws`, ...), `url.parse()`/`url.format()`/`url.resolve()` mis-handle the host, and the host ends up duplicated next to the port (`ssh:<host>:22<host>`), which then fails to parse as a port.

I reproduced this with Scaleway but this isn't specific to Scaleway or to IP hosts — I reproduced it locally against `docker-modem@5.0.6` and it fails identically for a bare IP, a hostname, and `localhost`. It's a deterministic bug in this dependency version, not an intermittent one, so automatic Wolf pairing could never have succeeded through this code path.

`SunshineMoonlightPairer` never hits this bug because it already uses the project's own `SSHClient` (`src/tools/ssh.ts`, built on `node-ssh`) instead of Dockerode's SSH transport — which is presumably why this stayed unnoticed for Sunshine users while Wolf users hit it every time.

## Fix

Replace the Dockerode/`docker-modem` SSH transport in `WolfMoonlightPairer` with the same `SSHClient` already used by `SunshineMoonlightPairer` and `InstanceRunner`:

- `buildDockerClient()` → `buildSshClient()`, returning a plain `SSHClient`.
- `getLatestPinURL()` / `checkPairingSuccess()` now run `docker logs wolf --tail <n> [--since <unix_ts>] 2>&1` over a real SSH exec instead of going through the Docker Engine API over SSH. Parsing logic (PIN URL regex, success-message match) is unchanged.
- `doPair()` opens one SSH connection for the whole polling loop and disposes it in a `finally`.

No behavior change other than how logs are fetched — the PIN-sending flow (`sendPinData`, HTTP POST to Wolf's `/pin/` endpoint) is untouched.

## Testing

- Reproduced the original bug in isolation with plain Node (`url.parse`/`format`/`resolve`, mirroring `docker-modem`'s `dial()`) to confirm the exact failure mode before writing the fix.
- `tsc -p tsconfig.build.json --noEmit`: no new errors (pre-existing unrelated errors in `src/cli/prompter.ts` are untouched by this change).
- `task test-unit`: all 155 existing tests pass.
- No existing unit tests cover `WolfMoonlightPairer`/`SunshineMoonlightPairer` pairing flow (network/SSH-dependent), so this change relies on the above + manual verification. Happy to add coverage if useful — let me know what you'd want tested.
- Manually tested pairing end-to-end against a live Scaleway instance (Wolf streaming server): manual pairing now succeeds, no more error loop.

## Note

This fix was drafted with Claude code AI assistance (root cause analysis, code change, local repro), then reviewed and validated end-to-end by me against a live instance before opening this PR.
